### PR TITLE
create data serializer

### DIFF
--- a/Studenda.Core.Server/Security/Controller/SecurityController.cs
+++ b/Studenda.Core.Server/Security/Controller/SecurityController.cs
@@ -1,12 +1,11 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Studenda.Core.Data;
 using Studenda.Core.Data.Transfer.Security;
+using Studenda.Core.Data.Util;
 using Studenda.Core.Model.Security;
 using Studenda.Core.Server.Security.Data;
 using Studenda.Core.Server.Security.Service;
@@ -87,20 +86,12 @@ public class SecurityController : ControllerBase
             return Unauthorized();
         }
 
-        var options = new JsonSerializerOptions
-        {
-            ReferenceHandler = ReferenceHandler.Preserve,
-            WriteIndented = true
-        };
-
-        var value = new SecurityResponse
+        return Ok(DataSerializer.Serialize(new SecurityResponse
         {
             User = user,
             Token = accessToken,
             RefreshToken = account.RefreshToken
-        };
-
-        return Ok(JsonSerializer.Serialize(value, options));
+        }));
     }
 
     [AllowAnonymous]

--- a/Studenda.Core/Data/Util/DataSerializer.cs
+++ b/Studenda.Core/Data/Util/DataSerializer.cs
@@ -30,12 +30,20 @@ public static class DataSerializer
     }
 
     /// <summary>
-    ///     Получить настройки сериализации.
+    ///     Конфигурация.
     /// </summary>
-    /// <returns>Настройки сериализации.</returns>
-    private static JsonSerializerSettings GetConfiguration() => new()
+    private static JsonSerializerSettings? Configuration { get; set; }
+
+    /// <summary>
+    ///     Получить конфигурацию.
+    /// </summary>
+    /// <returns>Конфигурация.</returns>
+    private static JsonSerializerSettings GetConfiguration()
     {
-        PreserveReferencesHandling = PreserveReferencesHandling.All,
-        DefaultValueHandling = DefaultValueHandling.Ignore
-    };
+        return Configuration ??= new JsonSerializerSettings
+        {
+            PreserveReferencesHandling = PreserveReferencesHandling.All,
+            DefaultValueHandling = DefaultValueHandling.Ignore
+        };
+    }
 }

--- a/Studenda.Core/Data/Util/DataSerializer.cs
+++ b/Studenda.Core/Data/Util/DataSerializer.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Studenda.Core.Data.Util;
+
+/// <summary>
+///     Класс-обертка для сериализации данных в формат JSON.
+/// </summary>
+public static class DataSerializer
+{
+    /// <summary>
+    ///     Сериализовать объект в строку JSON.
+    /// </summary>
+    /// <param name="rawData">Объект.</param>
+    /// <returns>Строка JSON.</returns>
+    public static string Serialize(object? rawData)
+    {
+        return JsonConvert.SerializeObject(rawData, GetConfiguration());
+    }
+
+    /// <summary>
+    ///     Десериализовать строку JSON в объект указанного типа данных.
+    /// </summary>
+    /// <param name="serializedData">Строка JSON.</param>
+    /// <typeparam name="T">Выходной тип данных.</typeparam>
+    /// <returns>Объект указанного выходного типа данных.</returns>
+    public static T? Deserialize<T>([StringSyntax("Json")] string serializedData)
+    {
+        return JsonConvert.DeserializeObject<T>(serializedData, GetConfiguration());
+    }
+
+    /// <summary>
+    ///     Получить настройки сериализации.
+    /// </summary>
+    /// <returns>Настройки сериализации.</returns>
+    private static JsonSerializerSettings GetConfiguration() => new()
+    {
+        PreserveReferencesHandling = PreserveReferencesHandling.All,
+        DefaultValueHandling = DefaultValueHandling.Ignore
+    };
+}

--- a/Studenda.Core/Data/Util/DataSerializer.cs
+++ b/Studenda.Core/Data/Util/DataSerializer.cs
@@ -15,7 +15,7 @@ public static class DataSerializer
     /// <returns>Строка JSON.</returns>
     public static string Serialize(object? rawData)
     {
-        return JsonConvert.SerializeObject(rawData, GetConfiguration());
+        return JsonConvert.SerializeObject(rawData, Configuration);
     }
 
     /// <summary>
@@ -26,24 +26,15 @@ public static class DataSerializer
     /// <returns>Объект указанного выходного типа данных.</returns>
     public static T? Deserialize<T>([StringSyntax("Json")] string serializedData)
     {
-        return JsonConvert.DeserializeObject<T>(serializedData, GetConfiguration());
+        return JsonConvert.DeserializeObject<T>(serializedData, Configuration);
     }
 
     /// <summary>
     ///     Конфигурация.
     /// </summary>
-    private static JsonSerializerSettings? Configuration { get; set; }
-
-    /// <summary>
-    ///     Получить конфигурацию.
-    /// </summary>
-    /// <returns>Конфигурация.</returns>
-    private static JsonSerializerSettings GetConfiguration()
+    private static JsonSerializerSettings Configuration { get; } = new()
     {
-        return Configuration ??= new JsonSerializerSettings
-        {
-            PreserveReferencesHandling = PreserveReferencesHandling.All,
-            DefaultValueHandling = DefaultValueHandling.Ignore
-        };
-    }
+        PreserveReferencesHandling = PreserveReferencesHandling.All,
+        DefaultValueHandling = DefaultValueHandling.Ignore
+    };
 }

--- a/Studenda.Core/Model/Common/Department.cs
+++ b/Studenda.Core/Model/Common/Department.cs
@@ -1,6 +1,5 @@
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Studenda.Core.Data.Configuration;
-using Studenda.Core.Model.Security;
 
 namespace Studenda.Core.Model.Common;
 

--- a/Studenda.Core/Model/Entity.cs
+++ b/Studenda.Core/Model/Entity.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Studenda.Core.Data.Configuration;
+using Studenda.Core.Data.Util;
 
 namespace Studenda.Core.Model;
 
@@ -19,7 +20,7 @@ public abstract class Entity
     /// <returns>Массив байтов.</returns>
     private static IEnumerable<byte> ComputeDataHash(Entity entity)
     {
-        var json = Newtonsoft.Json.JsonConvert.SerializeObject(entity);
+        var json = DataSerializer.Serialize(entity);
         var bytes = Encoding.UTF8.GetBytes(json);
 
         return MD5.HashData(bytes);


### PR DESCRIPTION
сделал статический класс для сериализации объектов. пригодится при передаче данных от сервера к клиенту. максимально ужал размер строк с помощью сторонней библиотеки.

пример обычной сериализации:
`{"$id":"1","CourseId":0,"DepartmentId":0,"Name":"Группа 1","Course":{"$id":"2","Grade":0,"Name":"Курс 1","Groups":{"$id":"3","$values":[{"$ref":"1"}]},"Id":0,"CreatedAt":"0001-01-01T00:00:00","UpdatedAt":null},"Department":{"$id":"4","Name":"Факультет 1","Groups":{"$id":"5","$values":[{"$ref":"1"}]},"Id":0,"CreatedAt":"0001-01-01T00:00:00","UpdatedAt":null},"Users":null,"StaticSchedules":null,"Id":0,"CreatedAt":"0001-01-01T00:00:00","UpdatedAt":null}`

пример сжатой:
`{"$id":"1","Name":"Группа 1","Course":{"$id":"2","Name":"Курс 1","Groups":{"$id":"3","$values":[{"$ref":"1"}]}},"Department":{"$id":"4","Name":"Факультет 1","Groups":{"$id":"5","$values":[{"$ref":"1"}]}}}`

эта разница позволит нам перемещать от сервера к клиенту в несколько раз больше данных за один запрос, либо снять нагрузку на сеть.